### PR TITLE
Handshake USB Persistence

### DIFF
--- a/notes/mk7_usb_persistence.txt
+++ b/notes/mk7_usb_persistence.txt
@@ -1,0 +1,19 @@
+Notes:
+
+	/root/loot is persistent (2G)
+
+
+
+Persistent handshakes on usb:
+
+	mount fat32 filesystem: 
+		mount /dev/sda1 /usb -t vfat
+		
+	make handshakes dir on usb:
+		mkdir /usb/handshakes/
+		
+	remove existing temp handshakes dir:
+		rm -rf /tmp/handshakes/
+		
+	softlink /tmp/handshakes to /usb/handshakes:	
+		ln -s /usb/handshakes /tmp/handshakes

--- a/scripts/hs_usb_persist.sh
+++ b/scripts/hs_usb_persist.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Persistent storage for captured handshakes on the Wifi Pineapple Mark VII	
+# Author: Tim Salomonsson
+
+#mount fat32 filesystem: 
+mount /dev/sda1 /usb -t vfat
+		
+#make handshakes dir on usb:
+mkdir /usb/handshakes/
+		
+#remove existing temp handshakes dir:
+rm -rf /tmp/handshakes/
+		
+#softlink /tmp/handshakes to /usb/handshakes:	
+ln -s /usb/handshakes /tmp/handshakes


### PR DESCRIPTION
The non-persistent location (/tmp/handshakes) is softlinked to /usb/handshakes.